### PR TITLE
Allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php": "^5.6.0 || ^7.0",
         "lorenzo/pinky": "^1.0",
-        "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
+        "symfony/framework-bundle": "^3.3 || ^4.0. || ^5.0",
         "tijsverkoyen/css-to-inline-styles": "^1.5 || ^2.0",
-        "twig/twig": "^1.23 || ^2.0"
+        "twig/twig": "^1.23 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,7 +12,7 @@
             <tag name="twig.extension" />
             <argument type="service" id="gremo_zurb_ink.util.html_utils" />
             <argument type="service" id="file_locator" />
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
         </service>
     </services>
 </container>

--- a/src/Twig/GremoZurbInkExtension.php
+++ b/src/Twig/GremoZurbInkExtension.php
@@ -16,9 +16,11 @@ use Gremo\ZurbInkBundle\Twig\Parser\InlineCssTokenParser;
 use Gremo\ZurbInkBundle\Util\HtmlUtils;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 use Twig_SimpleFunction;
 
-class GremoZurbInkExtension extends \Twig_Extension
+class GremoZurbInkExtension extends AbstractExtension
 {
     const NAME = 'gremo_zub_ink';
 
@@ -51,7 +53,7 @@ class GremoZurbInkExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('zurb_ink_add_stylesheet', [$this, 'addStylesheet']),
+            new TwigFunction('zurb_ink_add_stylesheet', [$this, 'addStylesheet']),
         ];
     }
 

--- a/src/Twig/GremoZurbInkExtension.php
+++ b/src/Twig/GremoZurbInkExtension.php
@@ -147,7 +147,7 @@ class GremoZurbInkExtension extends \Twig_Extension
         } catch (\Exception $exception) {
             // Only for Symfony 4, try also the "assets" folder (this will not work for customs "assets" folder)
             if (version_compare(Kernel::VERSION, 4, '>=')) {
-                $assetsDir = realpath(rtrim($this->rootDir, '\\/').'/../assets');
+                $assetsDir = realpath(rtrim($this->rootDir, '\\/').'/assets');
                 if ($assetsDir) {
                     return $this->fileLocator->locate($resource, $assetsDir);
                 }

--- a/src/Twig/Node/InkyNode.php
+++ b/src/Twig/Node/InkyNode.php
@@ -12,13 +12,16 @@
 namespace Gremo\ZurbInkBundle\Twig\Node;
 
 use Gremo\ZurbInkBundle\Twig\GremoZurbInkExtension;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Node\Node;
 use Twig_Compiler;
 use Twig_Environment;
 use Twig_Node;
 
-class InkyNode extends Twig_Node
+class InkyNode extends Node
 {
-    public function __construct(Twig_Node $body, $lineno = 0, $tag = 'inky')
+    public function __construct(Node $body, $lineno = 0, $tag = 'inky')
     {
         parent::__construct(['body' => $body], [], $lineno, $tag);
     }
@@ -26,9 +29,9 @@ class InkyNode extends Twig_Node
     /**
      * {@inheritdoc}
      */
-    public function compile(Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
-        $extensionName = (version_compare(Twig_Environment::VERSION, '1.26.0') >= 0)
+        $extensionName = (version_compare(Environment::VERSION, '1.26.0') >= 0)
             ? 'Gremo\ZurbInkBundle\Twig\GremoZurbInkExtension'
             : GremoZurbInkExtension::NAME
         ;

--- a/src/Twig/Node/InlineCssNode.php
+++ b/src/Twig/Node/InlineCssNode.php
@@ -12,13 +12,16 @@
 namespace Gremo\ZurbInkBundle\Twig\Node;
 
 use Gremo\ZurbInkBundle\Twig\GremoZurbInkExtension;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Node\Node;
 use Twig_Compiler;
 use Twig_Environment;
 use Twig_Node;
 
-class InlineCssNode extends Twig_Node
+class InlineCssNode extends Node
 {
-    public function __construct(Twig_Node $html, $lineno = 0, $tag = 'inlinestyle')
+    public function __construct(Node $html, $lineno = 0, $tag = 'inlinestyle')
     {
         parent::__construct(['html' => $html], [], $lineno, $tag);
     }
@@ -26,9 +29,9 @@ class InlineCssNode extends Twig_Node
     /**
      * {@inheritdoc}
      */
-    public function compile(Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
-        $extensionName = (version_compare(Twig_Environment::VERSION, '1.26.0') >= 0)
+        $extensionName = (version_compare(Environment::VERSION, '1.26.0') >= 0)
             ? 'Gremo\ZurbInkBundle\Twig\GremoZurbInkExtension'
             : GremoZurbInkExtension::NAME
         ;

--- a/src/Twig/Parser/InkyTokenParser.php
+++ b/src/Twig/Parser/InkyTokenParser.php
@@ -12,19 +12,21 @@
 namespace Gremo\ZurbInkBundle\Twig\Parser;
 
 use Gremo\ZurbInkBundle\Twig\Node\InkyNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 use Twig_Token;
 
-class InkyTokenParser extends \Twig_TokenParser
+class InkyTokenParser extends AbstractTokenParser
 {
     /**
      * {@inheritdoc}
      */
-    public function parse(Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineno = $token->getLine();
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new InkyNode($body, $lineno, $this->getTag());
     }
@@ -33,7 +35,7 @@ class InkyTokenParser extends \Twig_TokenParser
      * @param Twig_Token $token
      * @return bool
      */
-    public function decideBlockEnd(\Twig_Token $token)
+    public function decideBlockEnd(Token $token)
     {
         return $token->test('endinky');
     }

--- a/src/Twig/Parser/InlineCssTokenParser.php
+++ b/src/Twig/Parser/InlineCssTokenParser.php
@@ -12,31 +12,33 @@
 namespace Gremo\ZurbInkBundle\Twig\Parser;
 
 use Gremo\ZurbInkBundle\Twig\Node\InlineCssNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 use Twig_Token;
 use Twig_TokenParser;
 
-class InlineCssTokenParser extends Twig_TokenParser
+class InlineCssTokenParser extends AbstractTokenParser
 {
     /**
      * {@inheritdoc}
      */
-    public function parse(Twig_Token $token)
+    public function parse(Token $token)
     {
         $parser = $this->parser;
         $stream = $parser->getStream();
 
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $html = $this->parser->subparse([$this, 'decideBlockEnd'], true);
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new InlineCssNode($html, $token->getLine(), $this->getTag());
     }
 
     /**
-     * @param Twig_Token $token
+     * @param Token $token
      * @return bool
      */
-    public function decideBlockEnd(Twig_Token $token)
+    public function decideBlockEnd(Token $token)
     {
         return $token->test('endinlinestyle');
     }


### PR DESCRIPTION
This is work-in-progress.

So far, it seems these are the only necessary changes.

`kernel.root_dir` is no longer available, you have to use `kernel.project_dir` which is present since Symfony 3.3 (should be enough backward-compatibility).